### PR TITLE
Add Quote entity and update Status to use it

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,7 @@ jobs:
     
     steps:
     - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_16.1.app/Contents/Developer'
+      run: sudo xcode-select -s '/Applications/Xcode_16.4.app/Contents/Developer'
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/Sources/Swinub/Entity/Quote.swift
+++ b/Sources/Swinub/Entity/Quote.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public enum QuoteState: String, CaseIterable, Codable, Sendable {
+    case pending
+    case accepted
+    case rejected
+    case revoked
+    case deleted
+    case unauthorized
+}
+
+public struct Quote: Codable, Sendable {
+    public let state: QuoteState
+    public let status: Indirect<Status>?
+    
+    public init(from decoder: any Decoder) throws {
+        var state: QuoteState
+        var status: Indirect<Status>?
+        
+        do {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            state = try container.decode(QuoteState.self, forKey: .state)
+            status = try container.decodeIfPresent(Indirect<Status>.self, forKey: .status)
+        } catch {
+            do {
+                // fedibirdの場合
+                let container = try decoder.singleValueContainer()
+                state = .accepted
+                status = try container.decode(Indirect<Status>.self)
+            } catch {
+                throw error
+            }
+        }
+        
+        self.state = state
+        self.status = status
+    }
+}

--- a/Sources/Swinub/Entity/Quote.swift
+++ b/Sources/Swinub/Entity/Quote.swift
@@ -11,28 +11,28 @@ public enum QuoteState: String, CaseIterable, Codable, Sendable {
 
 public struct Quote: Codable, Sendable {
     public let state: QuoteState
-    public let status: Indirect<Status>?
+    public let quotedStatus: Indirect<Status>?
     
     public init(from decoder: any Decoder) throws {
         var state: QuoteState
-        var status: Indirect<Status>?
+        var quotedStatus: Indirect<Status>?
         
         do {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             state = try container.decode(QuoteState.self, forKey: .state)
-            status = try container.decodeIfPresent(Indirect<Status>.self, forKey: .status)
+            quotedStatus = try container.decodeIfPresent(Indirect<Status>.self, forKey: .quotedStatus)
         } catch {
             do {
                 // fedibirdの場合
                 let container = try decoder.singleValueContainer()
                 state = .accepted
-                status = try container.decode(Indirect<Status>.self)
+                quotedStatus = try container.decode(Indirect<Status>.self)
             } catch {
                 throw error
             }
         }
         
         self.state = state
-        self.status = status
+        self.quotedStatus = quotedStatus
     }
 }

--- a/Sources/Swinub/Entity/Status.swift
+++ b/Sources/Swinub/Entity/Status.swift
@@ -19,7 +19,7 @@ public struct Status: Codable, Identifiable, Sendable {
     public let language: String?
     public let reblog: Indirect<Status>?
     // fedibird
-    public let quote: Indirect<Status>?
+    public let quote: Quote?
     public let poll: Poll?
     public let card: PreviewCard?
     public let mediaAttachments: [MediaAttachment]


### PR DESCRIPTION
## Summary
- Add new Quote entity with QuoteState enum to handle quote status
- Update Status entity to use Quote type instead of Indirect<Status> for quote field
- Support both Mastodon and Fedibird quote formats through custom decoder

## Test plan
- [x] Verify Quote entity handles different quote states (pending, accepted, rejected, etc.)
- [x] Ensure Status entity properly uses new Quote type
- [x] Test compatibility with both Mastodon and Fedibird quote formats

🤖 Generated with [Claude Code](https://claude.ai/code)