### PR TITLE
[codex] Make application vapid key optional

### DIFF
--- a/Sources/Swinub/API/V1/Apps/Application.swift
+++ b/Sources/Swinub/API/V1/Apps/Application.swift
@@ -5,5 +5,5 @@ public struct Application: Codable, Identifiable, Sendable {
     public let redirectUri: String
     public let clientId: String
     public let clientSecret: String
-    public let vapidKey: String
+    public let vapidKey: String?
 }

--- a/Tests/SwinubTests/ApplicationTests.swift
+++ b/Tests/SwinubTests/ApplicationTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import Swinub
+
+@Suite
+struct ApplicationTests {
+    @Test func decodeWithoutVapidKey() async throws {
+        let json = """
+            {
+                "id": "123",
+                "name": "test app",
+                "website": null,
+                "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+                "client_id": "client-id",
+                "client_secret": "client-secret"
+            }
+            """
+        let data = Data(json.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let application = try decoder.decode(Application.self, from: data)
+        #expect(application.vapidKey == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Change `Application.vapidKey` from `String` to `String?`.
- Add a decode test that confirms an app response without `vapid_key` still decodes successfully and leaves `vapidKey` as `nil`.

## Validation

- `swift test --filter SwinubTests`