### PR TITLE
[codex] Update package dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "86e3875030b1a85e79841278197bd1e5648d7529516a0488967cfa2e55d911b0",
+  "originHash" : "3f9e34625f8bd412bc6aff08c9459127e235416217ae6030f7cc0c944e72f16b",
   "pins" : [
     {
       "identity" : "coretransferablebackport",
@@ -11,30 +11,12 @@
       }
     },
     {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms",
-      "state" : {
-        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
-        "version" : "1.0.4"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
-        "version" : "1.4.0"
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.4"),
-        .package(url: "https://github.com/apple/swift-http-types", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-http-types", from: "1.5.1"),
         .package(url: "https://github.com/noppefoxwolf/CoreTransferableBackport", from: "0.0.4"),
     ],
     targets: [
         .target(
             name: "Swinub",
             dependencies: [
-                .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
                 "CoreTransferableBackport",

--- a/Sources/Swinub/Request/EndpointRequestBasics.swift
+++ b/Sources/Swinub/Request/EndpointRequestBasics.swift
@@ -1,6 +1,5 @@
 import Foundation
 import HTTPTypes
-import HTTPTypesFoundation
 
 struct RequestFailedToMakeComponentsError: LocalizedError {
     var errorDescription: String? { "Request failed to make url components." }

--- a/Sources/Swinub/Request/HTTPEndpointRequestDefaults.swift
+++ b/Sources/Swinub/Request/HTTPEndpointRequestDefaults.swift
@@ -1,6 +1,5 @@
 import Foundation
 import HTTPTypes
-import HTTPTypesFoundation
 import CoreTransferable
 
 extension HTTPEndpointRequest {

--- a/Sources/Swinub/Request/HTTPEndpointRequestExtensions.swift
+++ b/Sources/Swinub/Request/HTTPEndpointRequestExtensions.swift
@@ -1,6 +1,5 @@
 import Foundation
 import HTTPTypes
-import HTTPTypesFoundation
 
 extension HTTPEndpointRequest {
     public func makeHTTPRequest() async throws -> (HTTPRequest, Data) {


### PR DESCRIPTION
## Summary

- Update `swift-http-types` from `1.4.0` to `1.5.1`.
- Remove unused direct dependency on `swift-async-algorithms`; this also removes the transitive `swift-collections` pin from `Package.resolved`.
- Drop `HTTPTypesFoundation` imports from request-building files that only need `HTTPTypes`; `URLSession` integration still imports `HTTPTypesFoundation` where it is used.

## Release notes reviewed

- `swift-http-types` `1.4.0` -> `1.5.1`: reviewed GitHub releases. Relevant updates include `HTTPRequest.url` moving to the main library in `1.5.0`, RFC8441 WebSocket URLRequest conversion, `QUERY` method support, Swift 6.1/6.2 CI updates, and the `1.5.1` FoundationEssentials patch.
- `swift-async-algorithms` `1.0.4` -> latest `1.1.3`: reviewed GitHub releases. Latest line adds `AsyncSequence.flatMapLatest`, `mapError`, `share` deadlock fixes, Swift 6 development toolchain fixes, and platform support improvements. The package was not imported anywhere in this repo, so it was removed instead of updated.
- `swift-collections` transitive `1.2.0` -> latest `1.4.1`: reviewed GitHub releases. It is only present through `swift-async-algorithms`, so removing the unused direct dependency removes this transitive dependency as well.
- `CoreTransferableBackport` `0.0.4`: checked GitHub tags/releases. `0.0.4` is still the latest tag and the repository has no GitHub release notes.

## Validation

- `swift package update`
- `swift package show-dependencies`
- `swift test`
- `git diff --check`