### PR TITLE
Allow nullable account bot flag

### DIFF
--- a/Sources/Swinub/Entity/Account.swift
+++ b/Sources/Swinub/Entity/Account.swift
@@ -24,7 +24,8 @@ public struct Account: Codable, Identifiable, Sendable {
     // fedibirds
     public let otherSettings: OtherSettings?
 
-    public let bot: Bool
+    // Sharkey instances such as ddoskey.com can return null for bot in notification accounts.
+    public let bot: Bool?
     public let locked: Bool
 
     public struct ID: Equatable, Hashable, Sendable, Codable, CustomStringConvertible {


### PR DESCRIPTION
## Summary
- make Account.bot optional for Sharkey-compatible responses
- document that ddoskey.com can return bot: null in notification account payloads

## Verification
- CLANG_MODULE_CACHE_PATH=.build/module-cache SWIFTPM_HOME=.build/swiftpm swift build
- CLANG_MODULE_CACHE_PATH=.build/module-cache SWIFTPM_HOME=.build/swiftpm SWINUB_ACCESS_TOKEN=<token> swift run swinub-cli mentions --host ddoskey.com --limit 5 --json