### PR TITLE
[codex] Add Fedibird quote status posting

### DIFF
--- a/Sources/Swinub/API/V1/Statuses/PostV1Statuses.swift
+++ b/Sources/Swinub/API/V1/Statuses/PostV1Statuses.swift
@@ -5,6 +5,13 @@ import HTTPTypes
 public struct PostV1Statuses: HTTPEndpointRequest, Sendable {
     public typealias Response = Status
 
+    public enum QuoteReference: Sendable {
+        // fedibird extension
+        case fedibird(Status.ID)
+        // Mastodon 4.5+
+        case mastodon(Status.ID)
+    }
+
     public struct Parameters: Sendable {
         public init() {}
         public var status: String = ""
@@ -16,6 +23,7 @@ public struct PostV1Statuses: HTTPEndpointRequest, Sendable {
         public var pollOptions: [String]? = nil
         public var pollExpiresIn: Int? = nil
         public var language: Locale.Language? = nil
+        public var quote: QuoteReference? = nil
         public var quoteApprovalPolicy: QuoteApprovalPolicy? = nil
     }
 
@@ -49,6 +57,14 @@ public struct PostV1Statuses: HTTPEndpointRequest, Sendable {
         }
         if let value = _parameters.language?.languageCode?.identifier {
             body["language"] = value
+        }
+        if let quote = _parameters.quote {
+            switch quote {
+            case .fedibird(let id):
+                body["quote_id"] = id.rawValue
+            case .mastodon(let id):
+                body["quoted_status_id"] = id.rawValue
+            }
         }
         if let value = _parameters.quoteApprovalPolicy {
             body["quote_approval_policy"] = value.rawValue

--- a/Tests/SwinubTests/PostV1StatusesTests.swift
+++ b/Tests/SwinubTests/PostV1StatusesTests.swift
@@ -21,4 +21,42 @@ struct PostV1StatusesTests {
             #expect(Bool(false))
         }
     }
+
+    @Test
+    func fedibirdQuoteParameter() throws {
+        var parameters = PostV1Statuses.Parameters()
+        parameters.quote = .fedibird(.init(rawValue: "fedibird-quote"))
+        let authorization = Authorization(host: "", accountID: .init(rawValue: ""), oauthToken: "")
+        let endpoint = PostV1Statuses(parameters: parameters, authorization: authorization)
+        let body = endpoint.body
+        switch body {
+        case .json(let jsonBody):
+            let dictionary = try #require(jsonBody as? [String: Any])
+            #expect(dictionary["quote_id"] as? String == "fedibird-quote")
+            #expect(dictionary["quoted_status_id"] == nil)
+        case .multipart:
+            #expect(Bool(false))
+        default:
+            #expect(Bool(false))
+        }
+    }
+
+    @Test
+    func mastodonQuoteParameter() throws {
+        var parameters = PostV1Statuses.Parameters()
+        parameters.quote = .mastodon(.init(rawValue: "mastodon-quote"))
+        let authorization = Authorization(host: "", accountID: .init(rawValue: ""), oauthToken: "")
+        let endpoint = PostV1Statuses(parameters: parameters, authorization: authorization)
+        let body = endpoint.body
+        switch body {
+        case .json(let jsonBody):
+            let dictionary = try #require(jsonBody as? [String: Any])
+            #expect(dictionary["quote_id"] == nil)
+            #expect(dictionary["quoted_status_id"] as? String == "mastodon-quote")
+        case .multipart:
+            #expect(Bool(false))
+        default:
+            #expect(Bool(false))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add quote status parameters to PostV1Statuses, including Fedibird's quote_id extension and Mastodon's quoted_status_id
- Add a swinub-cli post command for creating statuses and exercising quote posts
- Cover quote parameter JSON generation with a focused test

## Validation
- swift test
- swift build in SwinubCLI
- Confirmed a Fedibird quote post succeeds against fedibird.com with quote.state accepted