### PR TITLE
[codex] Add instance CLI command

### DIFF
--- a/Sources/Swinub/Entity/InstanceV2.swift
+++ b/Sources/Swinub/Entity/InstanceV2.swift
@@ -35,7 +35,7 @@ public struct Registrations: Codable, Sendable {
 
 public struct Contact: Codable, Sendable {
     public let email: String
-    public let account: Account
+    public let account: Account?
 }
 
 public struct Thumbnail: Codable, Sendable {

--- a/SwinubCLI/Sources/SwinubCLI/Instance.swift
+++ b/SwinubCLI/Sources/SwinubCLI/Instance.swift
@@ -1,0 +1,70 @@
+import ArgumentParser
+import Foundation
+import Swinub
+
+struct Instance: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "instance",
+        abstract: "Fetch instance metadata."
+    )
+
+    @Option(help: "Instance host, for example mastodon.social.")
+    var host: String
+
+    @Flag(help: "Print raw JSON.")
+    var json = false
+
+    mutating func run() async throws {
+        let instance = try await SwinubDefaults.session.response(
+            for: GetV2Instance(host: host)
+        ).response
+
+        if json {
+            try printJSON(instance)
+        } else {
+            printText(instance)
+        }
+    }
+
+    private func printJSON(_ instance: InstanceV2) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(instance)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Failed to encode instance as JSON.")
+        }
+        print(json)
+    }
+
+    private func printText(_ instance: InstanceV2) {
+        print("domain: \(instance.domain)")
+        print("title: \(instance.title)")
+        print("version: \(instance.version)")
+
+        if let mastodonAPIVersion = instance.apiVersions?.mastodon {
+            print("api_versions.mastodon: \(mastodonAPIVersion)")
+        }
+
+        if let capabilities = instance.fedibirdCapabilities, !capabilities.isEmpty {
+            let values = capabilities.map(fedibirdCapabilityValue).joined(separator: ", ")
+            print("fedibird_capabilities: \(values)")
+        }
+
+        print("max_characters: \(instance.configuration.statuses.maxCharacters)")
+        print("max_media_attachments: \(instance.configuration.statuses.maxMediaAttachments)")
+        print("registrations_enabled: \(instance.registrations.enabled)")
+        print("approval_required: \(instance.registrations.approvalRequired)")
+    }
+
+    private func fedibirdCapabilityValue(
+        _ capability: NonFrozenEnum<FedibirdCapability>
+    ) -> String {
+        switch capability {
+        case .value(let value):
+            value.rawValue
+        case .unknown(let value):
+            value
+        }
+    }
+}

--- a/SwinubCLI/Sources/SwinubCLI/main.swift
+++ b/SwinubCLI/Sources/SwinubCLI/main.swift
@@ -5,6 +5,6 @@ struct SwinubCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swinub-cli",
         abstract: "Utilities for working with Swinub.",
-        subcommands: [Auth.self, Mentions.self]
+        subcommands: [Auth.self, Instance.self, Mentions.self]
     )
 }


### PR DESCRIPTION
## Summary
- Add swinub-cli instance to fetch and print /api/v2/instance metadata
- Support JSON output for the instance response
- Make InstanceV2.Contact.account optional so instances such as mstdn.jp decode when the account is null

## Validation
- swift test
- swift build in SwinubCLI
- swift run swinub-cli instance --host mstdn.jp