### PR TITLE
[codex] Add instance feature quote flag

### DIFF
--- a/Sources/Swinub/Entity/InstanceV2.swift
+++ b/Sources/Swinub/Entity/InstanceV2.swift
@@ -11,6 +11,8 @@ public struct InstanceV2: Codable, Sendable {
     // Added Mastodon 4.3
     public let apiVersions: APIVersions?
     public let fedibirdCapabilities: [NonFrozenEnum<FedibirdCapability>]?
+    // Fedibird quote_id support flag. Mastodon upstream uses quoted_status_id and apiVersions.
+    public let featureQuote: Bool?
 }
 
 public struct APIVersions: Codable, Sendable {

--- a/Tests/SwinubTests/InstanceV2Tests.swift
+++ b/Tests/SwinubTests/InstanceV2Tests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import Swinub
+
+@Suite
+struct InstanceV2Tests {
+    @Test func decodesFeatureQuote() throws {
+        let json = """
+            {
+              "domain": "fedibird.com",
+              "title": "Fedibird",
+              "version": "3.4.1",
+              "description": "",
+              "thumbnail": {
+                "url": "https://example.com/thumbnail.png"
+              },
+              "rules": [],
+              "configuration": {
+                "accounts": {
+                  "max_featured_tags": 30
+                },
+                "statuses": {
+                  "max_characters": 560,
+                  "max_media_attachments": 20
+                },
+                "media_attachments": {
+                  "supported_mime_types": [],
+                  "image_size_limit": 25165824,
+                  "image_matrix_limit": 33177600,
+                  "video_size_limit": 103809024,
+                  "video_frame_rate_limit": 120,
+                  "video_matrix_limit": 8294400
+                },
+                "polls": {
+                  "max_options": 4,
+                  "max_characters_per_option": 50,
+                  "min_expiration": 300,
+                  "max_expiration": 2629746
+                }
+              },
+              "contact": {
+                "email": "support@example.com"
+              },
+              "registrations": {
+                "enabled": false,
+                "approval_required": false
+              },
+              "feature_quote": true
+            }
+            """
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let instance = try decoder.decode(InstanceV2.self, from: Data(json.utf8))
+
+        #expect(instance.featureQuote == true)
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for Fedibird's `feature_quote` field on the v2 instance entity by exposing it as `InstanceV2.featureQuote`.

## Impact

Clients can now detect whether a v2 instance response advertises quote support through the top-level `feature_quote` flag. The property is optional so instances that do not return the field continue to decode normally.

## Validation

- `swift test`
- Live decode checks with `swinub-cli instance --host ...` for `fedibird.com`, `mastodon.social`, `mstdn.jp`, `pawoo.net`, `fosstodon.org`, `social.vivaldi.net`, and `kmy.blue`